### PR TITLE
Fixes the crash caused when datastore is accessed outside of a singleton

### DIFF
--- a/app/src/main/java/io/dolby/rtsviewer/preferenceStore/PrefsStoreImpl.kt
+++ b/app/src/main/java/io/dolby/rtsviewer/preferenceStore/PrefsStoreImpl.kt
@@ -26,9 +26,9 @@ class PrefsStoreImpl @Inject constructor(
         val SHOW_LIVE_INDICATOR = booleanPreferencesKey("show_live_indicator")
     }
 
-    private val Context.dataStore by preferencesDataStore(
-        name = USER_PREFERENCES_STORE_NAME
-    )
+    companion object {
+        private val Context.dataStore by preferencesDataStore(name = USER_PREFERENCES_STORE_NAME)
+    }
 
     init {
         // Register default preference values, if it does not exist


### PR DESCRIPTION
Logs: You should either maintain your DataStore as a singleton or confirm that there is no two DataStore's active on the same file