### PR TITLE
Bugfix for TextInput focus change

### DIFF
--- a/app/src/main/java/io/dolby/rtsviewer/ui/detailInput/DetailInputScreen.kt
+++ b/app/src/main/java/io/dolby/rtsviewer/ui/detailInput/DetailInputScreen.kt
@@ -48,15 +48,15 @@ import io.dolby.rtsviewer.ui.alert.ClearStreamConfirmationAlert
 import io.dolby.rtsviewer.ui.alert.DetailInputValidationAlert
 import io.dolby.rtsviewer.uikit.button.ButtonType
 import io.dolby.rtsviewer.uikit.button.StyledButton
-import io.dolby.rtsviewer.uikit.input.TextInput
+import io.dolby.rtsviewer.uikit.input.TvTextInput
 import io.dolby.rtsviewer.uikit.theme.fontColor
 
 @Composable
 fun DetailInputScreen(
-    streamingData: StreamingData? = null,
     onPlayClick: (StreamingData) -> Unit,
     onSavedStreamsClick: () -> Unit,
     modifier: Modifier = Modifier,
+    streamingData: StreamingData? = null,
     viewModel: DetailInputViewModel = hiltViewModel()
 ) {
     var streamName by remember { mutableStateOf("") }
@@ -84,7 +84,6 @@ fun DetailInputScreen(
             )
         }
     }
-
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
@@ -168,7 +167,7 @@ fun DetailInputScreen(
 
                 Spacer(modifier = modifier.height(12.dp))
 
-                TextInput(
+                TvTextInput(
                     value = streamName,
                     label = stringResource(id = R.string.stream_name_placeholder),
                     onValueChange = {
@@ -183,15 +182,15 @@ fun DetailInputScreen(
 
                 Spacer(modifier = modifier.height(8.dp))
 
-                TextInput(
+                TvTextInput(
                     value = accountId,
                     label = stringResource(id = R.string.account_id_placeholder),
                     onValueChange = {
                         accountId = it
                     },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
-                        onNext = { localFocusManager.moveFocus(FocusDirection.Down) }
+                        onDone = { playStream(streamName, accountId) }
                     )
                 )
 

--- a/uikit/src/main/java/io/dolby/rtsviewer/uikit/input/TextInput.kt
+++ b/uikit/src/main/java/io/dolby/rtsviewer/uikit/input/TextInput.kt
@@ -1,6 +1,5 @@
 package io.dolby.rtsviewer.uikit.input
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -12,10 +11,7 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -25,7 +21,6 @@ import io.dolby.uikit.R
 
 internal val textInputContentDescriptionId = R.string.textInput_contentDescription
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Preview(showBackground = true)
 @Composable
 fun TextInput(
@@ -41,15 +36,9 @@ fun TextInput(
     val textState = remember { mutableStateOf(TextFieldValue(value)) }
     val textInputContentDescription =
         "${label.ifEmpty { textState.value.text }} ${stringResource(id = textInputContentDescriptionId)}"
-    val keyboardController = LocalSoftwareKeyboardController.current
     OutlinedTextField(
         modifier = modifier
             .fillMaxWidth()
-            .onFocusChanged {
-                if (it.isFocused) {
-                    keyboardController?.hide()
-                }
-            }
             .semantics { contentDescription = textInputContentDescription },
         value = textState.value,
         label = { Text(text = label, style = MaterialTheme.typography.body1) },
@@ -62,7 +51,7 @@ fun TextInput(
         keyboardActions = keyboardActions,
         enabled = enabled,
         readOnly = readOnly,
-        colors = TextFieldDefaults.textFieldColors(MaterialTheme.colors.onBackground),
+        colors = TextFieldDefaults.textFieldColors(colors.onBackground),
         maxLines = 1
     )
 }

--- a/uikit/src/main/java/io/dolby/rtsviewer/uikit/input/TvTextInput.kt
+++ b/uikit/src/main/java/io/dolby/rtsviewer/uikit/input/TvTextInput.kt
@@ -1,0 +1,94 @@
+package io.dolby.rtsviewer.uikit.input
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun TvTextInput(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    onValueChange: (String) -> Unit = {},
+    label: String = "",
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default
+) {
+    val isSelectedState = remember { mutableStateOf(false) }
+    val isActivatedState = remember { mutableStateOf(false) }
+
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val focusRequester = remember { FocusRequester() }
+    val scope = rememberCoroutineScope()
+    if (isFocused) {
+        LaunchedEffect(Unit) {
+            delay(200)
+            focusRequester.requestFocus()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled && !readOnly,
+                onClick = {
+                    scope.launch {
+                        isSelectedState.value = true
+                        delay(200)
+                        focusRequester.requestFocus()
+                    }
+                }
+            )
+            .onFocusChanged {
+                if (!it.isFocused && isActivatedState.value) {
+                    isActivatedState.value = false
+                    isSelectedState.value = false
+                } else if (it.isFocused && isSelectedState.value) {
+                    isActivatedState.value = true
+                }
+            }
+    ) {
+        if (isSelectedState.value) {
+            TextInput(
+                modifier.focusRequester(focusRequester),
+                value,
+                onValueChange,
+                label,
+                enabled,
+                readOnly,
+                keyboardOptions,
+                keyboardActions
+            )
+        } else {
+            TextInput(
+                modifier.focusRequester(focusRequester),
+                value,
+                onValueChange,
+                label,
+                enabled,
+                true,
+                keyboardOptions,
+                keyboardActions
+            )
+        }
+    }
+}


### PR DESCRIPTION
- Logic changed for TextInput on Android TV to avoid using Experimental compose API (which can lead to unwanted system behaviour)
- Changed action for accountId input (next to done)