### PR TITLE
[Bugfix] Details Input back action

### DIFF
--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/RecentStreamsScreen.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/RecentStreamsScreen.kt
@@ -1,6 +1,5 @@
 package io.dolby.interactiveplayer.savedStreams
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,7 +50,6 @@ import kotlin.math.min
 
 private const val RECENTLY_VIEWED_COUNT_TO_DISPLAY = 3
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RecentStreamsScreen(
     modifier: Modifier = Modifier,
@@ -69,6 +67,9 @@ fun RecentStreamsScreen(
     LaunchedEffect(Unit) {
         delay(500)
         loading = false
+        if (uiState.recentStreams.isEmpty()) {
+            onPlayNewClick()
+        }
     }
 
     Scaffold(
@@ -85,11 +86,11 @@ fun RecentStreamsScreen(
                 .padding(paddingValues)
                 .semantics { contentDescription = screenName }
         ) {
-            if (loading) {
+            if (uiState.loading || loading) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 }
-            } else if (uiState.recentStreams.isNotEmpty()) {
+            } else {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = modifier
@@ -185,8 +186,6 @@ fun RecentStreamsScreen(
                         buttonType = ButtonType.PRIMARY
                     )
                 }
-            } else {
-                onPlayNewClick()
             }
         }
     }

--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/SavedStreamScreenUiState.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/SavedStreamScreenUiState.kt
@@ -3,5 +3,6 @@ package io.dolby.interactiveplayer.savedStreams
 import io.dolby.interactiveplayer.datastore.StreamDetail
 
 data class SavedStreamScreenUiState(
-    val recentStreams: List<StreamDetail> = emptyList()
+    val recentStreams: List<StreamDetail> = emptyList(),
+    val loading: Boolean = true
 )

--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/SavedStreamViewModel.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/savedStreams/SavedStreamViewModel.kt
@@ -37,7 +37,8 @@ class SavedStreamViewModel @Inject constructor(
                 .collectLatest {
                     _uiState.update { state ->
                         state.copy(
-                            recentStreams = it
+                            recentStreams = it,
+                            loading = false
                         )
                     }
                 }


### PR DESCRIPTION
+ fixed logic to redirect from Recent Streams to Details Input when there's no recent streams
+ wait until the latest Recent Streams loaded
