### PR TITLE
[Bugfix] Reactivated audio source

### DIFF
--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
@@ -144,13 +144,11 @@ class MultiStreamingRepository(
             e.printStackTrace()
         }
         _data.update { data -> data.copy(streamingData = streamingData) }
-        listenForAudioSelection()
     }
 
     fun disconnect() {
         _data.update { MultiStreamingData() }
         listener?.disconnect()
-        listenForAudioSelection()
     }
 
     private fun credential(

--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
@@ -434,7 +434,7 @@ class MultiStreamingRepository(
         }
 
         fun playAudio(audioTrack: MultiStreamingData.Audio) {
-            val audioTrackIds = ArrayList(data.value.audioTracks.map { it.id })
+            val audioTrackIds = ArrayList(data.value.allAudioTrackIds)
             subscriber?.unproject(audioTrackIds)
 
             val projectionData = ProjectionData().also {

--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/domain/MultiStreamingData.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/domain/MultiStreamingData.kt
@@ -7,6 +7,7 @@ import io.dolby.interactiveplayer.rts.data.MultiStreamingRepository
 data class MultiStreamingData(
     val videoTracks: List<Video> = emptyList(),
     val audioTracks: List<Audio> = emptyList(),
+    val allAudioTrackIds: List<String?> = arrayListOf(),
     val selectedVideoTrackId: String? = null,
     val selectedAudioTrackId: String? = null,
     val viewerCount: Int = 0,
@@ -61,7 +62,10 @@ data class MultiStreamingData(
         val audioTracks = audioTracks.toMutableList().apply {
             add(Audio(id, audioTrack, sourceId))
         }
-        return copy(audioTracks = audioTracks, pendingAudioTracks = pendingAudioTracks)
+        val allAudioTracks = allAudioTrackIds.toMutableList().apply {
+            add(id)
+        }
+        return copy(audioTracks = audioTracks, allAudioTrackIds = allAudioTracks, pendingAudioTracks = pendingAudioTracks)
     }
 
     internal fun getPendingVideoTrackInfoOrNull(): PendingTrack? = pendingVideoTracks.firstOrNull()

--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/streaming/multiview/SingleStreamingScreen.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/streaming/multiview/SingleStreamingScreen.kt
@@ -86,10 +86,12 @@ fun SingleStreamingScreen(
                 initialPage = initialPage,
                 pageCount = { uiState.videoTracks.size }
             )
-            LaunchedEffect(pagerState) {
-                snapshotFlow { pagerState.currentPage }.collect { page ->
-                    if (uiState.videoTracks.isNotEmpty()) {
-                        viewModel.selectVideoTrack(uiState.videoTracks[page].sourceId)
+            if (uiState.videoTracks.isNotEmpty()) {
+                LaunchedEffect(pagerState) {
+                    snapshotFlow { pagerState.currentPage }.collect { page ->
+                        if (uiState.videoTracks.isNotEmpty()) {
+                            viewModel.selectVideoTrack(uiState.videoTracks[page].sourceId)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Workaround for the audio source that has been re-activated with another mid (to unproject the audio track using old mid)
- Bugfix for SingleStreamView not starting the audio