### PR TITLE
[Bugfix] onSignalingError to match iOS logic

### DIFF
--- a/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
+++ b/interactiveplayer/src/main/java/io/dolby/interactiveplayer/rts/data/MultiStreamingRepository.kt
@@ -328,9 +328,6 @@ class MultiStreamingRepository(
 
         override fun onSignalingError(p0: String?) {
             Log.d(TAG, "onSignalingError: $p0")
-            data.update {
-                it.populateError(error = p0 ?: "Signaling error")
-            }
         }
 
         override fun onStatsReport(p0: RTCStatsReport?) {


### PR DESCRIPTION
`onSignalingError` should not propagate the error