### PR TITLE
RTS Monitor bugfixes for connection close

### DIFF
--- a/app/src/main/java/io/dolby/rtsviewer/ui/streaming/StreamingScreen.kt
+++ b/app/src/main/java/io/dolby/rtsviewer/ui/streaming/StreamingScreen.kt
@@ -100,8 +100,8 @@ fun StreamingScreen(viewModel: StreamingViewModel = hiltViewModel(), onBack: () 
             } else if (showSettings.value) {
                 viewModel.settingsVisibility(false)
             } else {
-                viewModel.disconnect()
                 onBack.invoke()
+                viewModel.clear()
             }
         }
     }

--- a/app/src/main/java/io/dolby/rtsviewer/ui/streaming/StreamingViewModel.kt
+++ b/app/src/main/java/io/dolby/rtsviewer/ui/streaming/StreamingViewModel.kt
@@ -2,7 +2,6 @@ package io.dolby.rtsviewer.ui.streaming
 
 import android.icu.text.SimpleDateFormat
 import android.util.Log
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,10 +10,7 @@ import io.dolby.rtscomponentkit.data.SingleStreamStatisticsData
 import io.dolby.rtscomponentkit.utils.DispatcherProvider
 import io.dolby.rtsviewer.R
 import io.dolby.rtsviewer.preferenceStore.PrefsStore
-import io.dolby.rtsviewer.ui.navigation.Screen
 import io.dolby.rtsviewer.utils.NetworkStatusObserver
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,10 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -33,15 +26,12 @@ import java.text.CharacterIterator
 import java.text.StringCharacterIterator
 import java.util.Date
 import javax.inject.Inject
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "StreamingViewModel"
 private const val SHOW_TOOLBAR_TIMEOUT: Long = 5_000
 
 @HiltViewModel
 class StreamingViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle,
     private val repository: RTSViewerDataStore,
     private val dispatcherProvider: DispatcherProvider,
     private val preferencesDataStore: PrefsStore,
@@ -68,18 +58,9 @@ class StreamingViewModel @Inject constructor(
     private val _showSimulcastSettings = MutableStateFlow(false)
     var showSimulcastSettings = _showSimulcastSettings.asStateFlow()
 
-    init {
-        viewModelScope.launch {
-            tickerFlow(5.seconds)
-                .onEach {
-                    if (!_uiState.value.connecting && (_uiState.value.error != null || _uiState.value.disconnected)) {
-                        Log.d(TAG, "Reconnect: ${this@StreamingViewModel}")
-                        connect()
-                    }
-                }
-                .launchIn(viewModelScope)
-        }
+    private var alreadyCleared = false
 
+    init {
         viewModelScope.launch {
             repository.state.combine(networkStatusObserver.status) { f1, f2 -> Pair(f1, f2) }
                 .collect { (dataStoreState, networkStatus) ->
@@ -132,7 +113,6 @@ class StreamingViewModel @Inject constructor(
                             }
                             RTSViewerDataStore.State.StreamInactive -> {
                                 Log.d(TAG, "StreamInactive")
-                                repository.disconnect()
                                 withContext(dispatcherProvider.main) {
                                     _uiState.update { state ->
                                         state.copy(
@@ -229,35 +209,13 @@ class StreamingViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        viewModelScope.cancel()
-        viewModelScope.coroutineContext.cancelChildren()
-        repository.disconnect()
+        clear()
     }
 
-    fun disconnect() {
-        repository.disconnect()
-    }
-
-    private suspend fun connect() {
-        val streamName = getStreamName(savedStateHandle)
-        val accountId = getAccountId(savedStateHandle)
-        withContext(dispatcherProvider.main) {
-            _uiState.update { it.copy(accountId = accountId, streamName = streamName) }
-        }
-        repository.connect(streamName, accountId)
-    }
-
-    private fun getStreamName(handle: SavedStateHandle): String =
-        handle[Screen.StreamingScreen.ARG_STREAM_NAME] ?: throw IllegalArgumentException()
-
-    private fun getAccountId(handle: SavedStateHandle): String =
-        handle[Screen.StreamingScreen.ARG_ACCOUNT_ID] ?: throw IllegalArgumentException()
-
-    private fun tickerFlow(period: Duration, initialDelay: Duration = Duration.ZERO) = flow {
-        delay(initialDelay)
-        while (true) {
-            emit(Unit)
-            delay(period)
+    fun clear() {
+        if (!alreadyCleared) {
+            alreadyCleared = true
+            repository.disconnect()
         }
     }
 

--- a/rtscomponentkit/src/main/java/io/dolby/rtscomponentkit/data/RTSViewerDataStore.kt
+++ b/rtscomponentkit/src/main/java/io/dolby/rtscomponentkit/data/RTSViewerDataStore.kt
@@ -94,10 +94,9 @@ class RTSViewerDataStore constructor(
         apiUrl = "https://director.millicast.com/api/director/subscribe"
     )
 
-    fun disconnect() = apiScope.launch {
-        val previousValue = listener
+    fun disconnect() {
+        listener?.release()
         listener = null
-        previousValue?.stopSubscribeAndDisconnect()
 
         resetStreamQualityTypes()
     }

--- a/rtscomponentkit/src/main/java/io/dolby/rtscomponentkit/data/SingleStreamListener.kt
+++ b/rtscomponentkit/src/main/java/io/dolby/rtscomponentkit/data/SingleStreamListener.kt
@@ -251,7 +251,7 @@ class SingleStreamListener(
         Log.d(
             TAG,
             "onLayers: $mid, ${activeLayers.contentToString()}, ${
-                inactiveLayers.contentToString()
+            inactiveLayers.contentToString()
             }"
         )
         val filteredActiveLayers = mutableListOf<LayerData>()


### PR DESCRIPTION
- force clear `viewModel` on Back pressed in case if the screen will be reopened fast;
- refactored `StreamingViewModel.kt` (removed old timer for reconnecting);
- don't disconnect on `StreamInactive`, just throw an error;
- `state` from sdk is collected as distinct to avoid duplicates which break the app logic (`Subscribed` just after `StreamInactive` etc)